### PR TITLE
Improve Lec12 ANOVA: fix typos, convert Stata to R, add model comparison

### DIFF
--- a/notes/Lec12.ANOVA.Model.Choice.qmd
+++ b/notes/Lec12.ANOVA.Model.Choice.qmd
@@ -35,7 +35,7 @@ tryCatch(source('pander_registry.R'), error = function(e) invisible(e))
 
     -   of trend in means AND
 
-    -   standard errors withing groups
+    -   standard errors within groups
 
 -   ANOVA (dummy variables)
 
@@ -90,18 +90,14 @@ y2 <- 300 + 200*(dose==20) + 100*(dose==40) - 100*(dose==60) + 0*(dose==80) + rn
 
 m1 <- lm(y1 ~ dose)
 m2 <- lm(y1 ~ factor(dose))
-
-#m3 <- lm(y2 ~ dose)
 m4 <- lm(y2 ~ factor(dose))
 
 p1 <- predict(m1, newdata=data.frame(dose=dose.levels), se.fit=TRUE)
 p2 <- predict(m2, newdata=data.frame(dose=dose.levels), se.fit=TRUE)
-
-#p3 <- predict(m3, newdata=data.frame(dose=dose.levels), se.fit=TRUE)
 p4 <- predict(m4, newdata=data.frame(dose=dose.levels), se.fit=TRUE)
 ```
 
-```{r, fig.height=8, fig.cap="Comparsion of power using ANOVA versus linear dose for detecting a dose effect for various dose-response relationships"}
+```{r, fig.height=8, fig.cap="Comparison of power using ANOVA versus linear dose for detecting a dose effect for various dose-response relationships"}
 par(mfrow=c(2,2))
 plotCI(x=dose.levels, y=p1$fit, p1$se.fit, ylab="Response", xlab="Dose", ylim=c(0,1000), main="Linear: High power; ANOVA: High Power")
 plotCI(x=dose.levels, y=p1$fit, 3*p1$se.fit, ylab="Response", xlab="Dose", ylim=c(0,1000), main="Linear: Mod power; ANOVA: Low Power")
@@ -158,7 +154,7 @@ plotCI(x=dose.levels[c(1,5,4,2,3)], y=p1$fit, 3*p1$se.fit, ylab="Response", xlab
 
         -   With confounders, failure to accurately model the relationship between the confounder and the response may lead to residual confounding
 
-            -   Sometimes we will use very flexible models for continuous confounders as there is little cost to doing so and the potential for imporant gain
+            -   Sometimes we will use very flexible models for continuous confounders as there is little cost to doing so and the potential for important gain
 
     -   As the goal of any analysis is to communicate findings to the greater scientific community, it is also important that modeling of predictors is easy to understand
 
@@ -178,7 +174,7 @@ plotCI(x=dose.levels[c(1,5,4,2,3)], y=p1$fit, 3*p1$se.fit, ylab="Response", xlab
 
     -   We should select the form of modeling the predictor before looking at the data
 
-        -   Data drive selection of transformations will tend to lead to inaccurate (anti-conservative) statistical inference
+        -   Data driven selection of transformations will tend to lead to inaccurate (anti-conservative) statistical inference
 
         -   Overfitting of the data leads to spuriously low estimates of the within group variability
 
@@ -209,11 +205,15 @@ plotCI(x=dose.levels[c(1,5,4,2,3)], y=p1$fit, 3*p1$se.fit, ylab="Response", xlab
 ```{r}
 carot <- stata.get("data/carot.dta")
 res1 <- aggregate(carot3 ~ dose, data = carot,
-FUN = function(x) c(n = length(x), mean = mean(x), sd = sd(x),
-min = min(x), q25 = quantile(x, 0.25),
-median = median(x), q75 = quantile(x, 0.75),
-max = max(x)))
-data.frame(dose = res1$dose, res1$carot3, check.names = FALSE)
+  FUN = function(x) c(n = length(x), mean = mean(x), sd = sd(x),
+    min = min(x), q25 = quantile(x, 0.25),
+    median = median(x), q75 = quantile(x, 0.75),
+    max = max(x)))
+res1_df <- data.frame(Dose = res1$dose, res1$carot3, check.names = FALSE)
+kable(res1_df, digits=1,
+      col.names = c("Dose", "N", "Mean", "SD", "Min", "Q25", "Median", "Q75", "Max"),
+      caption = "Summary of 9-month plasma beta-carotene by dose group") |>
+  kable_styling(bootstrap_options = c("striped", "hover"), full_width = FALSE)
 ```
 
 -   In this randomized trial, we can consider several potential response variables
@@ -327,12 +327,16 @@ coeftest(m.factor, vcov=sandwich)
 ```
 
 ```{r}
+# Helper objects used across all dose-response plots
+m1 <- lm(carot3 ~ factor(dose), data=carot)
+dose.seq <- seq(0, 60, by=15)
+group.means <- predict(m1, newdata=data.frame(dose=dose.seq))
+
 plot(jitter(carot$dose, factor=.2), carot$carot3, ylab="Plasma Beta Carotene", xlab="Dose of Supplementation", main="Model: Dummy Variables (ANOVA)")
-m1 <- lm(carot3~factor(dose), data=carot)
-points(seq(0,60, by=15), predict(m1, newdata=data.frame(dose=seq(0,60, by=15))), pch="O", cex=2)
-points(seq(0,60, by=15), predict(m1, newdata=data.frame(dose=seq(0,60, by=15))), pch="X", cex=2)
-lines(seq(0,60, by=15), predict(m1, newdata=data.frame(dose=seq(0,60, by=15))))
-legend("topleft", c("Fitted", "Group Means"), pch=c("X","O"), lty=c(NA,1), bty="n")
+lines(dose.seq, group.means)
+points(dose.seq, group.means, pch="O", cex=2)
+points(dose.seq, group.means, pch="X", cex=2)
+legend("topleft", c("Fitted", "Group Means"), pch=c("X","O"), bty="n")
 ```
 
 -   Testing for the dose effect
@@ -369,7 +373,7 @@ linearHypothesis(m2.factor, c("dose.new0",
 
 -   Note that the parameter estimates all will lead to the same fitted values
 
-    -   e.g. Intercept in above model (1430) equals the intercept + dose60 coefficient (-361 + 1791) in previous model
+    -   e.g. Intercept in the re-leveled model equals the intercept + dose60 coefficient in the original model
 
 -   Overall F statistics, R-squared, Root MSE all the same
 
@@ -378,8 +382,6 @@ linearHypothesis(m2.factor, c("dose.new0",
 -   Could also fit the same model with no intercept
 
     -   Would then have to include all five dose groups
-
-    -   We can get Stata to include fit all five dose groups and no intercept using the `noconstant` option
 
     -   In R, fit a model without an intercept by adding a $-1$ in the model equation (e.g. $y \sim -1 + x$)
 
@@ -498,7 +500,7 @@ legend("topleft", c("Fitted", "Group Means"), pch=c("X","O"), lty=c(NA,1), bty="
 
 -   The partial t-test for dosesqr can be interpreted as a test for linear dose response
 
-    -   It is highly significant, suggestion departure from linearity
+    -   It is highly significant, suggesting departure from linearity
 
 -   To test the treatment effect, we need to test the two dose covariates
 
@@ -518,52 +520,15 @@ linearHypothesis(m.poly, c("poly(dose, 2)1",
 
     -   Highest order polynomial borrows no information across dose groups
 
-<!-- -->
+```{r}
+m.poly4 <- lm(carot3 ~ poly(dose, 4, raw=TRUE) + carot0, data=carot)
+coeftest(m.poly4, vcov=sandwich)
+```
 
-```stata
-. gen dosecub = dose^3
-. gen dosequad = dose^4
-. regress carot3 dose dosesqr dosecub dosequad carot0, robust
+-   Compare to the ANOVA model — same fit statistics (R-squared, Root MSE, F-statistic)
 
-Linear regression                                      Number of obs =      40
-                                                       F(  5,    34) =   47.68
-                                                       Prob > F      =  0.0000
-                                                       R-squared     =  0.7184
-                                                       Root MSE      =  417.46
-
-------------------------------------------------------------------------------
-             |               Robust
-      carot3 |      Coef.   Std. Err.      t    P>|t|     [95% Conf. Interval]
--------------+----------------------------------------------------------------
-        dose |    157.876   61.94333     2.55   0.015     31.99197    283.7599
-     dosesqr |  -6.943752   5.066692    -1.37   0.180    -17.24051    3.353004
-     dosecub |   .1385695   .1313523     1.05   0.299    -.1283706    .4055096
-    dosequad |  -.0009734   .0010718    -0.91   0.370    -.0031515    .0012047
-      carot0 |   1.902792   .5370015     3.54   0.001     .8114738     2.99411
-       _cons |  -361.4516   167.5432    -2.16   0.038    -701.9404   -20.96284
-------------------------------------------------------------------------------
-
-
-. xi: regress carot3 i.dose carot0, robust
-i.dose            _Idose_0-60         (naturally coded; _Idose_0 omitted)
-
-Linear regression                                      Number of obs =      40
-                                                       F(  5,    34) =   47.68
-                                                       Prob > F      =  0.0000
-                                                       R-squared     =  0.7184
-                                                       Root MSE      =  417.46
-
-------------------------------------------------------------------------------
-             |               Robust
-      carot3 |      Coef.   Std. Err.      t    P>|t|     [95% Conf. Interval]
--------------+----------------------------------------------------------------
-   _Idose_15 |    1224.19   213.5586     5.73   0.000     790.1863    1658.193
-   _Idose_30 |   1439.837   155.7948     9.24   0.000     1123.224     1756.45
-   _Idose_45 |   1678.984   167.1502    10.04   0.000     1339.294    2018.674
-   _Idose_60 |   1791.009    152.946    11.71   0.000     1480.185    2101.833
-      carot0 |   1.902792   .5370015     3.54   0.001     .8114738     2.99411
-       _cons |  -361.4516   167.5432    -2.16   0.038    -701.9404   -20.96284
-------------------------------------------------------------------------------
+```{r}
+coeftest(m.factor, vcov=sandwich)
 ```
 
 ### Threshold at 0 and Linear Term
@@ -582,26 +547,9 @@ Linear regression                                      Number of obs =      40
 
         -   Is there any additional benefit beyond the lowest dose? (test linear term's slope)
 
-<!-- -->
-
-```stata
-. regress carot3 trt dose carot0, robust
-
-Linear regression                                      Number of obs =      40
-                                                       F(  3,    36) =   81.26
-                                                       Prob > F      =  0.0000
-                                                       R-squared     =  0.7170
-                                                       Root MSE      =  406.69
-
-------------------------------------------------------------------------------
-             |               Robust
-      carot3 |      Coef.   Std. Err.      t    P>|t|     [95% Conf. Interval]
--------------+----------------------------------------------------------------
-         trt |   1050.836    223.418     4.70   0.000     597.7237    1503.949
-        dose |   12.81144   4.794314     2.67   0.011     3.088122    22.53476
-      carot0 |   1.904584   .5164903     3.69   0.001     .8570932    2.952075
-       _cons |  -361.9675   161.4254    -2.24   0.031    -689.3534   -34.58168
-------------------------------------------------------------------------------
+```{r}
+m.thres <- lm(carot3 ~ trt + dose + carot0, data=carot)
+coeftest(m.thres, vcov=sandwich)
 ```
 
 ```{r}
@@ -633,16 +581,59 @@ legend("topleft", c("Fitted", "Group Means"), pch=c("X","O"), lty=c(NA,1), bty="
 
     -   There is a multiple comparison issue here, but many people are comfortable doing this 'step down' test after they have already tested from any treatment effect
 
-<!-- -->
+```{r}
+linearHypothesis(m.thres, c("trt", "dose"), vcov=sandwich(m.thres))
+```
 
-```         
-. test trt dose
+### Summary comparison of models
 
- ( 1)  trt = 0
- ( 2)  dose = 0
+-   Comparing all models side by side helps illustrate the trade-off between parsimony and flexibility
 
-       F(  2,    36) =  121.88
-            Prob > F =    0.0000
+```{r, fig.cap="Comparison of fitted values from all dose-response models against group means"}
+dose.seq <- seq(0, 60, by=15)
+group.means <- predict(m1, newdata=data.frame(dose=dose.seq))
+
+plot(jitter(carot$dose, factor=.2), carot$carot3,
+     ylab="Plasma Beta Carotene", xlab="Dose of Supplementation",
+     main="All Models Compared", col="gray70", pch=16)
+points(dose.seq, group.means, pch=16, cex=2)
+
+# Fitted values from each unadjusted model
+m2.plot <- lm(carot3 ~ dose, data=carot)
+m3.plot <- lm(carot3 ~ poly(dose, 2), data=carot)
+m4.plot <- lm(carot3 ~ (dose > 0), data=carot)
+
+lines(dose.seq, predict(m2.plot, newdata=data.frame(dose=dose.seq)), col="blue", lwd=2)
+lines(dose.seq, predict(m3.plot, newdata=data.frame(dose=dose.seq)), col="red", lwd=2)
+lines(dose.seq, predict(m4.plot, newdata=data.frame(dose=dose.seq)), col="darkgreen", lwd=2, lty=2)
+lines(dose.seq, predict(m5, newdata=data.frame(dose=dose.seq)), col="purple", lwd=2, lty=3)
+lines(dose.seq, group.means, col="black", lwd=2, lty=1)
+
+legend("topleft",
+       c("Group Means (ANOVA)", "Linear", "Quadratic", "Dichotomized", "Threshold + Linear"),
+       col=c("black", "blue", "red", "darkgreen", "purple"),
+       lwd=2, lty=c(1,1,1,2,3), bty="n", cex=0.85)
+```
+
+```{r}
+# Model comparison table (all adjusted for baseline)
+model_names <- c("ANOVA (dummy variables)", "Dichotomized", "Linear", "Quadratic", "Threshold + Linear")
+model_list <- list(m.factor, m.trt, m.cont, m.poly, m.thres)
+model_df <- min(sapply(model_list, function(m) c("df" = m$df.residual)))
+
+comp_table <- data.frame(
+  Model = model_names,
+  `Dose df` = c(4, 1, 1, 2, 2),
+  `Residual df` = sapply(model_list, function(m) m$df.residual),
+  `R-squared` = sapply(model_list, function(m) summary(m)$r.squared),
+  `Root MSE` = sapply(model_list, function(m) summary(m)$sigma),
+  AIC = sapply(model_list, AIC),
+  check.names = FALSE
+)
+
+kable(comp_table, digits=c(0, 0, 0, 3, 1, 1),
+      caption = "Comparison of dose-response models (all adjusted for baseline)") |>
+  kable_styling(bootstrap_options = c("striped", "hover"), full_width = FALSE)
 ```
 
 ## Data driven model selection
@@ -677,58 +668,51 @@ legend("topleft", c("Fitted", "Group Means"), pch=c("X","O"), lty=c(NA,1), bty="
 
     -   Calculate how often each model rejects the null hypothesis of a dose effect
 
-```{r, eval=FALSE}
+```{r, cache=TRUE}
 set.seed(80)
 
 reps <- 1000
 n <- length(carot$carot3)
 p.vals <- matrix(NA, nrow=reps, ncol=5)
+colnames(p.vals) <- c("ANOVA", "Linear", "Quadratic", "Dichotomized", "Dichot + Linear")
 
 y <- carot$carot3
 y0 <- carot$carot0
 m.restrict <- lm(y ~ y0)
 
 for(i in 1:reps) {
- perm <- sample(1:n)
+  perm <- sample(1:n)
 
-#Permute the dose, but not the outcome and baseline
- d <- carot$dose[perm]
+  # Permute the dose, but not the outcome and baseline
+  d <- carot$dose[perm]
 
- m.anova <- lm(y ~ y0 + factor(d))
- m.linear <- lm(y ~ y0 + d)
- m.quad <- lm(y ~ y0 + poly(d,2))
- m.dichot <- lm(y ~ y0 + (d>0))
- m.dilin <- lm(y ~ y0 + d + (d>0))
+  m.anova <- lm(y ~ y0 + factor(d))
+  m.linear <- lm(y ~ y0 + d)
+  m.quad <- lm(y ~ y0 + poly(d,2))
+  m.dichot <- lm(y ~ y0 + (d>0))
+  m.dilin <- lm(y ~ y0 + d + (d>0))
 
- p.vals[i,1:5] <- c(anova(m.anova)[2,"Pr(>F)"], anova(m.linear)[2,"Pr(>F)"],  anova(m.quad)[2,"Pr(>F)"],  anova(m.dichot)[2,"Pr(>F)"], anova(m.restrict, m.dilin)[2,"Pr(>F)"])
+  p.vals[i, ] <- c(anova(m.anova)[2,"Pr(>F)"],
+                    anova(m.linear)[2,"Pr(>F)"],
+                    anova(m.quad)[2,"Pr(>F)"],
+                    anova(m.dichot)[2,"Pr(>F)"],
+                    anova(m.restrict, m.dilin)[2,"Pr(>F)"])
 }
-
-# Proportion significant by model
-apply(p.vals<0.05, 2, mean)
-
-1.96*sqrt(.05*(1-.05)/reps)
-
-
-table(apply(p.vals<.05,1, sum)) / reps
-# Propotion where at least 1 was significant
-p.hat <- sum(apply(p.vals<.05,1, sum) >= 1) / reps
-
-p.hat
-p.hat + c(-1.96,1.96)*sqrt(p.hat*(1-p.hat)/reps)
 ```
 
 -   Individual Model Results
 
     -   Empirical type I error for each method of analysis individually
 
-    |                 |                   |
-    |:----------------|------------------:|
-    | Model           | Emp. Type-I error |
-    | ANOVA           |             0.049 |
-    | Linear          |             0.046 |
-    | Quadratic       |             0.046 |
-    | Dichotomized    |             0.050 |
-    | Dichot + linear |             0.041 |
+```{r}
+sim_results <- data.frame(
+  Model = colnames(p.vals),
+  `Emp. Type-I Error` = apply(p.vals < 0.05, 2, mean),
+  check.names = FALSE)
+kable(sim_results, digits=3,
+      caption = "Empirical type I error rate by model (nominal = 0.05)") |>
+  kable_styling(bootstrap_options = c("striped", "hover"), full_width = FALSE)
+```
 
 -   Multiple comparison issues
 
@@ -740,13 +724,18 @@ p.hat + c(-1.96,1.96)*sqrt(p.hat*(1-p.hat)/reps)
 
         -   In fact, the tests will be correlated
 
-    -   How many of the 1000 simulated trials had at least on model with a $p$-value $< 0.05$?
+    -   How many of the 1000 simulated trials had at least one model with a $p$-value $< 0.05$?
 
-        -   From the simulation, I found this to be $122$ or $12.2\%$
+```{r}
+p.hat <- mean(apply(p.vals < 0.05, 1, any))
+ci <- p.hat + c(-1.96, 1.96) * sqrt(p.hat * (1 - p.hat) / reps)
+```
+
+        -   From the simulation, this was `r sum(apply(p.vals < 0.05, 1, any))` or `r sprintf("%.1f%%", 100 * p.hat)`
 
         -   Note that there is error in this estimate (due to the simulation randomness)
 
-            -   95% CI: \[$10.2\%, 14.2\%$\]
+            -   95% CI: [`r sprintf("%.1f%%", 100 * ci[1])`, `r sprintf("%.1f%%", 100 * ci[2])`]
 
 -   General statistical issues
 
@@ -788,17 +777,19 @@ p.hat + c(-1.96,1.96)*sqrt(p.hat*(1-p.hat)/reps)
 
 -   Experiment-wise error rates ($\alpha = 0.05$ at each decision)
 
-    |             |            |             |
-    |:-----------:|:----------:|:-----------:|
-    |  Number of  | Worst Case | Independent |
-    | Comparisons |  Scenario  |   Errors    |
-    |      1      |   0.0500   |   0.0500    |
-    |      2      |   0.1000   |   0.0975    |
-    |      3      |   0.1500   |   0.1426    |
-    |      5      |   0.2500   |   0.2262    |
-    |     10      |   0.5000   |   0.4013    |
-    |     20      |   1.0000   |   0.6415    |
-    |     50      |   1.0000   |   0.9231    |
+```{r}
+alpha <- 0.05
+k <- c(1, 2, 3, 5, 10, 20, 50)
+ewer_table <- data.frame(
+  `Number of Comparisons` = k,
+  `Worst Case (Bonferroni bound)` = pmin(k * alpha, 1),
+  `Independent Errors` = round(1 - (1 - alpha)^k, 4),
+  check.names = FALSE
+)
+kable(ewer_table, digits=4,
+      caption = "Experiment-wise error rates at nominal alpha = 0.05") |>
+  kable_styling(bootstrap_options = c("striped", "hover"), full_width = FALSE)
+```
 
 -   When making multiple comparison which all tend address the same scientific question, we may adjust our level of significance to protect the experiment-wise error rate
 
@@ -833,3 +824,31 @@ p.hat + c(-1.96,1.96)*sqrt(p.hat*(1-p.hat)/reps)
         -   Understand the science
 
         -   Avoid data-driven approaches when you care about correct statistical inference (CIs and p-values)
+
+## Practical Guidelines
+
+-   Pre-specify your model before looking at the data
+
+    -   Use scientific knowledge and prior studies to guide model choice
+
+    -   Document the analysis plan (ideally in a protocol or statistical analysis plan)
+
+-   When in doubt, use flexible but pre-specified approaches
+
+    -   Restricted cubic splines with a pre-specified number of knots provide a good balance between flexibility and parsimony
+
+    -   The number of knots can be chosen based on the sample size, not the data pattern
+
+-   If you must explore multiple models, be transparent
+
+    -   Report all models considered, not just the "winner"
+
+    -   Use information criteria (AIC, BIC) rather than p-values for model selection when the goal is prediction
+
+    -   Acknowledge the exploratory nature of the analysis
+
+-   Remember the hierarchy of goals
+
+    1.  Address the scientific question
+    2.  Protect the validity of inference
+    3.  Maximize precision (power)


### PR DESCRIPTION
- Fix typos: withing→within, Comparsion→Comparison, imporant→important, drive→driven, suggestion→suggesting, on→one
- Convert all remaining Stata output blocks to executable R code: 4th-degree polynomial, threshold+linear model, joint F-test
- Format tables with kable/kableExtra (descriptive stats, simulation results, experiment-wise error rates, model comparison)
- Enable simulation chunk with caching (was eval=FALSE)
- Use inline R expressions for simulation results instead of hardcoded values
- Remove commented-out unused code (m3/p3) and Stata-specific references
- Add model comparison summary table and overlay plot of all fitted models
- Add practical guidelines section on pre-specification and transparency
- Clean up ANOVA plot code and legend consistency

https://claude.ai/code/session_01GWupCi2K56oPZi4EDSx6vT